### PR TITLE
Fix for empty arrays on prettier 3.3

### DIFF
--- a/src/printer/insert-new-lines.ts
+++ b/src/printer/insert-new-lines.ts
@@ -63,7 +63,7 @@ function insertLinesIntoArray(
                 parentDoc[childIndex + 2] = maybeBreak.breakContents;
             }
             const indentIndex = childIndex + 1;
-            const bracketSibling = parentDoc[indentIndex];
+            const bracketSibling = parentDoc[indentIndex] === '' ? parentDoc[indentIndex + 1] : parentDoc[indentIndex];
             if (debug) {
                 console.info({bracketSibling});
             }


### PR DESCRIPTION
I'm not sure if this may have some unintended side-effects but it seems that from `prettier@3.3.0` there is an extra empty string inserted into the doc. It seems to pass all tests on both `prettier@3.3.0` and `prettier@3.2.0` so I don't believe it would break anything.

Fixes #32 